### PR TITLE
Fix wrong syntax for git submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,10 +21,10 @@
 	url = git://github.com/getsentry/raven-python.git
 [submodule "src/basket-client"]
 	path = src/basket-client
-	url = https://github.com/mozilla/basket-client.git
+	url = git://github.com/mozilla/basket-client.git
 [submodule "src/dnspython"]
 	path = src/dnspython
-	url = git@github.com:rthalley/dnspython
+	url = git://github.com/rthalley/dnspython.git
 [submodule "src/requests"]
 	path = src/requests
-	url = git@github.com:kennethreitz/requests
+	url = git://github.com/kenneithreitz/requests.git


### PR DESCRIPTION
Apparently git is pickier when checking out these submodules from Jenkins than when I'm fiddling with them locally.
